### PR TITLE
POC for Prevent Empty and Whitespace-Only Strings and Standardise String Validation Logic

### DIFF
--- a/app/shared/controllers/validators/resolvers/ResolveStringPattern.scala
+++ b/app/shared/controllers/validators/resolvers/ResolveStringPattern.scala
@@ -24,18 +24,21 @@ import scala.util.matching.Regex
 
 case class ResolveStringPattern(regexFormat: Regex, error: MtdError) extends ResolverSupport {
 
-  val resolver: Resolver[String, String] = value =>
-    if (regexFormat.matches(value))
-      Valid(value)
-    else
-      Invalid(List(error))
+  val resolver: Resolver[String, String] = value => if (value.trim.nonEmpty && regexFormat.matches(value)) Valid(value) else Invalid(List(error))
 
   def apply(value: String): Validated[Seq[MtdError], String] = resolver(value)
+
+  def apply(value: Option[String]): Validated[Seq[MtdError], Option[String]] = resolver.resolveOptionally(value)
 }
 
 object ResolveStringPattern {
 
   def apply(value: String, regexFormat: Regex, error: MtdError): Validated[Seq[MtdError], String] = {
+    val resolver = ResolveStringPattern(regexFormat, error)
+    resolver(value)
+  }
+
+  def apply(value: Option[String], regexFormat: Regex, error: MtdError): Validated[Seq[MtdError], Option[String]] = {
     val resolver = ResolveStringPattern(regexFormat, error)
     resolver(value)
   }

--- a/app/v2/createAmendPensions/def1/Def1_CreateAmendPensionsRulesValidator.scala
+++ b/app/v2/createAmendPensions/def1/Def1_CreateAmendPensionsRulesValidator.scala
@@ -17,10 +17,9 @@
 package v2.createAmendPensions.def1
 
 import cats.data.Validated
-import cats.data.Validated.Invalid
 import cats.implicits.toFoldableOps
 import shared.controllers.validators.RulesValidator
-import shared.controllers.validators.resolvers.{ResolveParsedCountryCode, ResolveParsedNumber}
+import shared.controllers.validators.resolvers.{ResolveParsedCountryCode, ResolveParsedNumber, ResolveStringPattern}
 import shared.models.errors.MtdError
 import v2.createAmendPensions.def1.model.request.{CreateAmendForeignPensionsItem, CreateAmendOverseasPensionContributions}
 import v2.createAmendPensions.model.request.Def1_CreateAmendPensionsRequestData
@@ -68,29 +67,8 @@ object Def1_CreateAmendPensionsRulesValidator extends RulesValidator[Def1_Create
   private def resolveNonNegativeNumber(value: Option[BigDecimal], path: String): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber()(value, path)
 
-  private def validateCustomerRef(ref: String, path: String, error: MtdError = CustomerRefFormatError): Validated[Seq[MtdError], Unit] =
-    if (stringRegex.matches(ref)) valid
-    else Invalid(List(error.withPath(path)))
-
-  private def validateQopsRef(ref: String, path: String, error: MtdError = QOPSRefFormatError): Validated[Seq[MtdError], Unit] =
-    if (stringRegex.matches(ref)) valid
-    else Invalid(List(error.withPath(path)))
-
-  private def validatesf74Ref(ref: String, path: String, error: MtdError = SF74RefFormatError): Validated[Seq[MtdError], Unit] =
-    if (stringRegex.matches(ref)) valid
-    else Invalid(List(error.withPath(path)))
-
-  private def validateDoubleTaxationArticle(ref: String,
-                                            path: String,
-                                            error: MtdError = DoubleTaxationArticleFormatError): Validated[Seq[MtdError], Unit] =
-    if (stringRegex.matches(ref)) valid
-    else Invalid(List(error.withPath(path)))
-
-  private def validateDoubleTaxationTreaty(ref: String,
-                                           path: String,
-                                           error: MtdError = DoubleTaxationTreatyFormatError): Validated[Seq[MtdError], Unit] =
-    if (stringRegex.matches(ref)) valid
-    else Invalid(List(error.withPath(path)))
+  private def resolveStringByPattern(value: Option[String], error: MtdError): Validated[Seq[MtdError], Option[String]] =
+    ResolveStringPattern(value, stringRegex, error)
 
   private def validatePensionsItem(foreignPensionsItem: CreateAmendForeignPensionsItem, index: Int): Validated[Seq[MtdError], Unit] = {
 
@@ -112,14 +90,14 @@ object Def1_CreateAmendPensionsRulesValidator extends RulesValidator[Def1_Create
     def path(suffix: String) = s"/overseasPensionContributions/$index/$suffix"
 
     combine(
-      pensionContributions.customerReference.traverse_(validateCustomerRef(_, path("customerReference"))),
+      resolveStringByPattern(pensionContributions.customerReference, CustomerRefFormatError.withPath(path("customerReference"))),
       resolveParsedNumber(pensionContributions.exemptEmployersPensionContribs, path("exemptEmployersPensionContribs")),
-      pensionContributions.migrantMemReliefQopsRefNo.traverse_(validateQopsRef(_, path("migrantMemReliefQopsRefNo"))),
+      resolveStringByPattern(pensionContributions.migrantMemReliefQopsRefNo, QOPSRefFormatError.withPath(path("migrantMemReliefQopsRefNo"))),
       resolveNonNegativeNumber(pensionContributions.dblTaxationRelief, path("dblTaxationRelief")),
       ResolveParsedCountryCode(pensionContributions.dblTaxationCountryCode, path("dblTaxationCountryCode")),
-      pensionContributions.dblTaxationArticle.traverse_(validateDoubleTaxationArticle(_, path("dblTaxationArticle"))),
-      pensionContributions.dblTaxationTreaty.traverse_(validateDoubleTaxationTreaty(_, path("dblTaxationTreaty"))),
-      pensionContributions.sf74reference.traverse_(validatesf74Ref(_, path("sf74reference")))
+      resolveStringByPattern(pensionContributions.dblTaxationArticle, DoubleTaxationArticleFormatError.withPath(path("dblTaxationArticle"))),
+      resolveStringByPattern(pensionContributions.dblTaxationTreaty, DoubleTaxationTreatyFormatError.withPath(path("dblTaxationTreaty"))),
+      resolveStringByPattern(pensionContributions.sf74reference, SF74RefFormatError.withPath(path("sf74reference")))
     )
 
   }

--- a/resources/public/api/conf/2.0/schemas/pensions_definitions.json
+++ b/resources/public/api/conf/2.0/schemas/pensions_definitions.json
@@ -69,7 +69,7 @@
         "properties": {
           "customerReference": {
             "type": "string",
-            "description": "A reference the user supplies to identify the record.",
+            "description": "A reference the user supplies to identify the record. Must not be empty or contain only whitespace.",
             "example": "PENSIONINCOME245",
             "pattern": "^[0-9a-zA-Z{À-˿’}\\- _&`():.'^]{1,90}$"
           },
@@ -83,7 +83,7 @@
           },
           "migrantMemReliefQopsRefNo": {
             "type": "string",
-            "description": "The qualifying overseas pension scheme reference number for migrant member relief.",
+            "description": "The qualifying overseas pension scheme reference number for migrant member relief. Must not be empty or contain only whitespace.",
             "example": "QOPS000000",
             "pattern": "^[0-9a-zA-Z{À-˿’}\\- _&`():.'^]{1,90}$"
           },
@@ -102,19 +102,19 @@
           },
           "dblTaxationArticle": {
             "type": "string",
-            "description": "The taxation article reference number.",
+            "description": "The taxation article reference number. Must not be empty or contain only whitespace.",
             "example": "AB3211-1",
             "pattern": "^[0-9a-zA-Z{À-˿’}\\- _&`():.'^]{1,90}$"
           },
           "dblTaxationTreaty": {
             "type": "string",
-            "description": "The name of the treaty that has the right to collect tax.",
+            "description": "The name of the treaty that has the right to collect tax. Must not be empty or contain only whitespace.",
             "example": "MUNICH",
             "pattern": "^[0-9a-zA-Z{À-˿’}\\- _&`():.'^]{1,90}$"
           },
           "sf74reference": {
             "type": "string",
-            "description": "The SF74 reference number for transitional corresponding relief claims.",
+            "description": "The SF74 reference number for transitional corresponding relief claims. Must not be empty or contain only whitespace.",
             "example": "SF74-123456",
             "pattern": "^[0-9a-zA-Z{À-˿’}\\- _&`():.'^]{1,90}$"
           }

--- a/test/shared/controllers/validators/resolvers/ResolveStringPatternSpec.scala
+++ b/test/shared/controllers/validators/resolvers/ResolveStringPatternSpec.scala
@@ -28,21 +28,96 @@ class ResolveStringPatternSpec extends UnitSpec {
   private val resolveTaxYearPattern = ResolveStringPattern(taxYearRegex, TaxYearFormatError)
 
   "ResolveStringPattern" should {
-    "return the input value" when {
+    "return no errors" when {
       "given a matching string" in {
         val result = resolveTaxYearPattern("2024-25")
         result shouldBe Valid("2024-25")
+      }
+
+      "given a matching string in an Option" in {
+        val result = resolveTaxYearPattern(Some("2024-25"))
+        result shouldBe Valid(Some("2024-25"))
+      }
+
+      "given an empty Option" in {
+        val result = resolveTaxYearPattern(None)
+        result shouldBe Valid(None)
       }
 
       "given a matching string via the legacy apply() function" in {
         val result = ResolveStringPattern("2024-25", taxYearRegex, TaxYearFormatError)
         result shouldBe Valid("2024-25")
       }
+
+      "given a matching string in an Option via the legacy apply() function" in {
+        val result = ResolveStringPattern(Some("2024-25"), taxYearRegex, TaxYearFormatError)
+        result shouldBe Valid(Some("2024-25"))
+      }
+
+      "given an empty Option via the legacy apply() function" in {
+        val result = ResolveStringPattern(None, taxYearRegex, TaxYearFormatError)
+        result shouldBe Valid(None)
+      }
     }
 
     "return the expected error" when {
       "given a non-matching string and no override error" in {
         val result = resolveTaxYearPattern("does-not-match-regex")
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a non-matching string in an Option and no override error" in {
+        val result = resolveTaxYearPattern(Some("does-not-match-regex"))
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a non-matching string via the legacy apply() function and no override error" in {
+        val result = ResolveStringPattern("does-not-match-regex", taxYearRegex, TaxYearFormatError)
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a non-matching string in an Option via the legacy apply() function and no override error" in {
+        val result = ResolveStringPattern(Some("does-not-match-regex"), taxYearRegex, TaxYearFormatError)
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given an empty string" in {
+        val result = resolveTaxYearPattern("")
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given an empty string in an Option" in {
+        val result = resolveTaxYearPattern(Some(""))
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given an empty string via the legacy apply() function" in {
+        val result = ResolveStringPattern("", taxYearRegex, TaxYearFormatError)
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given an empty string in an Option via the legacy apply() function" in {
+        val result = ResolveStringPattern(Some(""), taxYearRegex, TaxYearFormatError)
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a string with only spaces" in {
+        val result = resolveTaxYearPattern("   ")
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a string with only spaces in an Option" in {
+        val result = resolveTaxYearPattern(Some("   "))
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a string with only spaces via the legacy apply() function" in {
+        val result = ResolveStringPattern("   ", taxYearRegex, TaxYearFormatError)
+        result shouldBe Invalid(List(TaxYearFormatError))
+      }
+
+      "given a string with only spaces in an Option via the legacy apply() function" in {
+        val result = ResolveStringPattern(Some("   "), taxYearRegex, TaxYearFormatError)
         result shouldBe Invalid(List(TaxYearFormatError))
       }
     }


### PR DESCRIPTION
String validation is currently inconsistent, with some fields relying on regex-based validation and others using custom conditional logic. This can allow empty strings or whitespace-only values to be accepted during submission.

When such values are submitted, downstream systems may return validation errors. In some cases, particularly for mandatory fields, these errors are only surfaced during retrieval, as empty or whitespace-only values are not currently handled consistently downstream.

To address this, validation should be standardised and enhanced to ensure that input values are not empty after trimming whitespace. This should be enforced across all relevant string fields by using a consistent validation approach, ensuring that both empty strings and whitespace-only inputs are rejected at the point of submission.

Additionally, existing string validation logic should be aligned to use the updated `ResolveStringPattern`, avoiding the use of custom conditional checks for string validation.