### PR TITLE
POC to replace CORS configuration with CORSActionBuilder to resolve documentation rendering issues

### DIFF
--- a/app/shared/controllers/DocumentationController.scala
+++ b/app/shared/controllers/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,37 @@
 package shared.controllers
 
 import controllers.RewriteableAssets
+import org.apache.pekko.stream.Materializer
+import play.api.Configuration
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.filters.cors.CORSActionBuilder
 import shared.config.rewriters.DocumentationRewriters
 import shared.definition.ApiDefinitionFactory
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class DocumentationController @Inject() (
     selfAssessmentApiDefinition: ApiDefinitionFactory,
     docRewriters: DocumentationRewriters,
     assets: RewriteableAssets,
+    configuration: Configuration,
     cc: ControllerComponents
-) extends BackendController(cc) {
+)(implicit ec: ExecutionContext, materializer: Materializer)
+    extends BackendController(cc) {
 
   def definition(): Action[AnyContent] = Action {
     Ok(Json.toJson(selfAssessmentApiDefinition.definition))
   }
 
-  def asset(version: String, filename: String): Action[AnyContent] = {
-    val path      = s"/public/api/conf/$version"
-    val rewriters = docRewriters.rewriteables.flatMap { _.maybeRewriter(version, filename) }
-    assets.rewriteableAt(path, filename, rewriters)
-  }
+  def asset(version: String, filename: String): Action[AnyContent] =
+    CORSActionBuilder(configuration).async { implicit request =>
+      val path      = s"/public/api/conf/$version"
+      val rewriters = docRewriters.rewriteables.flatMap { _.maybeRewriter(version, filename) }
+      assets.rewriteableAt(path, filename, rewriters)(request)
+    }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2026 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@ minimumPermittedTaxYear = 2020
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "config.PensionsIncomePlayModule"
-play.filters.enabled += "play.filters.cors.CORSFilter"
-play.filters.cors {allowedOrigins = ["http://localhost:9680"]}
 
 # Json error handler
 play.http.errorHandler = "shared.utils.ErrorHandler"

--- a/test/shared/controllers/DocumentationControllerSpec.scala
+++ b/test/shared/controllers/DocumentationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package shared.controllers
 
 import com.typesafe.config.ConfigFactory
 import controllers.{AssetsConfiguration, DefaultAssetsMetadata, RewriteableAssets}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.testkit.NoMaterializer
 import play.api.http.{DefaultFileMimeTypes, DefaultHttpErrorHandler, FileMimeTypesConfiguration, HttpConfiguration}
 import play.api.mvc.Result
 import play.api.{Configuration, Environment}
@@ -175,6 +177,8 @@ class DocumentationControllerSpec extends ControllerBaseSpec with MockAppConfig 
 
     MockedAppConfig.featureSwitchConfig returns Configuration("openApiFeatureTest.enabled" -> featureEnabled)
 
+    private implicit val materializer: Materializer = NoMaterializer
+
     private val apiFactory = new ApiDefinitionFactory {
       protected val appConfig: AppConfig = mockAppConfig
 
@@ -212,7 +216,7 @@ class DocumentationControllerSpec extends ControllerBaseSpec with MockAppConfig 
     )
 
     private val assets       = new RewriteableAssets(errorHandler, assetsMetadata, mock[Environment])
-    protected def controller = new DocumentationController(apiFactory, docRewriters, assets, cc)
+    protected def controller = new DocumentationController(apiFactory, docRewriters, assets, config, cc)
   }
 
 }


### PR DESCRIPTION
This API currently enables the **CORSFilter** and configures **allowedOrigins** to include http://localhost:9680, which is the port used by the [api-documentation-frontend](https://github.com/hmrc/api-documentation-frontend). This configuration was introduced to resolve Cross-Origin Resource Sharing (CORS) issues encountered when rendering API documentation locally, allowing API Platform to retrieve the specification file from the API. However, because the configuration is defined in **application.conf**, it applies to all environments, including production. This results in [configuration warnings](https://catalogue.tax.service.gov.uk/config/warnings/search/results?serviceName=individuals-pensions-income-api) highlighting that a **localhost** origin is permitted in environments where it is not required.

The warning could be resolved by overriding the configuration and setting **allowedOrigins** to an empty value in non-local environments, however, this is not the preferred approach. As the underlying issue only exists when rendering API documentation locally, a configuration-driven solution that affects all environments should be avoided. Instead, the current implementation should be replaced with a solution using **CORSActionBuilder**, ensuring that CORS handling is applied only for local API documentation rendering. This removes the need for a globally configured **localhost** origin while continuing to support local API documentation rendering.